### PR TITLE
Changes to struct and creation function

### DIFF
--- a/rusty-merkle-tree/src/main.rs
+++ b/rusty-merkle-tree/src/main.rs
@@ -5,7 +5,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 //Hashvalues are of type u64. The type aliasing to HashValue is there to help with code readability.
 //TODO: Implement Add for further declarativeness in code
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 struct HashValue(u64);
 
 
@@ -39,7 +39,17 @@ fn createMerkleTreeFromData<T: Hash>(data: Vec<T>) -> MerkleTreeNode {
     while current_layer.len() > 1 {
 
         //If number of elements is odd, I clone the last element and add it as another block to hash
-        if current_layer.len() % 2 != 0 { current_layer.push(current_layer.last().unwrap().clone()); }
+        if current_layer.len() % 2 != 0 { 
+
+            let last_element = current_layer.last().unwrap();
+            let last_element_clone = MerkleTreeNode {
+                hash: last_element.hash,
+                leftChild: last_element.leftChild.clone(),
+                rightChild: last_element.rightChild.clone()
+            };
+
+            current_layer.push(last_element_clone); 
+        }
 
         let mut next_layer = Vec::new();
 

--- a/rusty-merkle-tree/src/main.rs
+++ b/rusty-merkle-tree/src/main.rs
@@ -37,6 +37,10 @@ fn createMerkleTreeFromData<T: Hash>(data: Vec<T>) -> MerkleTreeNode {
     //When there's only one left, that one is the root, and I'm done
     //TODO: Currently only works if the vector size is a factor of two. Research further on how to appropriately handle cases where it isn't
     while current_layer.len() > 1 {
+
+        //If number of elements is odd, I clone the last element and add it as another block to hash
+        if current_layer.len() % 2 != 0 { current_layer.push(current_layer.last().unwrap().clone()); }
+
         let mut next_layer = Vec::new();
 
         let mut current_layer_iter = current_layer.iter();

--- a/rusty-merkle-tree/src/main.rs
+++ b/rusty-merkle-tree/src/main.rs
@@ -17,8 +17,20 @@ struct MerkleTreeNode{
     rightChild: Option<Box<MerkleTreeNode>>,
 }
 
+struct MerkleTree {
+    root: MerkleTreeNode,
+    size: u32,
+}
+
+fn closestBiggerPowerOf2 (num: f64) -> u32 {
+    let exp = f64::log2(num).ceil();
+    f64::powf(2.0, exp) as u32
+
+
+}
+
 //Takes a vector with data, and returns a merkle tree derived from the hashes of each element in the vector
-fn createMerkleTreeFromData<T: Hash>(data: Vec<T>) -> MerkleTreeNode {
+fn createMerkleTreeFromData<T: Hash>(data: Vec<T>) -> MerkleTree {
     
     
     let mut current_layer = Vec::new();
@@ -77,15 +89,20 @@ fn createMerkleTreeFromData<T: Hash>(data: Vec<T>) -> MerkleTreeNode {
     }
 
     //Because of how the while is structured, only the root will be left in the vector.
-    //I get the first element and return it
+    //I get the first element and use it for the tree root
     let root = current_layer.first().unwrap().clone();
-    root
+    let size= closestBiggerPowerOf2(data.len() as f64);
+    let tree =  MerkleTree { root, size };
+    tree
+    
 
     
     
 
 
 }
+
+
 
 fn main() {
 
@@ -104,7 +121,7 @@ mod tests {
         let merkle_tree_42 = createMerkleTreeFromData(vec![test_int]);
         let mut hasher = DefaultHasher::new();
         test_int.hash(&mut hasher);
-        assert_eq!(merkle_tree_42.hash.0, hasher.finish());
+        assert_eq!(merkle_tree_42.root.hash.0, hasher.finish());
 
     }
 
@@ -154,28 +171,28 @@ mod tests {
         let hash_root = hasher_root.finish();
         
         
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().leftChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[0]);
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().leftChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[1]);
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().rightChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[2]);
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().rightChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[3]);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().leftChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[4]);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().leftChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[4]);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().rightChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[4]);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().rightChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[4]);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().leftChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[0]);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().leftChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[1]);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().rightChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[2]);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().rightChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[3]);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().leftChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[4]);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().leftChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[4]);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().rightChild.unwrap().leftChild.unwrap().hash.0, hashed_ints[4]);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().rightChild.unwrap().rightChild.unwrap().hash.0, hashed_ints[4]);
 
 
 
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().leftChild.unwrap().hash.0, hash1);
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().rightChild.unwrap().hash.0, hash2);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().leftChild.unwrap().hash.0, hash3);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().rightChild.unwrap().hash.0, hash3);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().leftChild.unwrap().hash.0, hash1);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().rightChild.unwrap().hash.0, hash2);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().leftChild.unwrap().hash.0, hash3);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().rightChild.unwrap().hash.0, hash3);
 
         
-        assert_eq!(merkle_tree.leftChild.unwrap().hash.0, hash4);
-        assert_eq!(merkle_tree.rightChild.unwrap().hash.0, hash5);
+        assert_eq!(merkle_tree.root.leftChild.unwrap().hash.0, hash4);
+        assert_eq!(merkle_tree.root.rightChild.unwrap().hash.0, hash5);
 
 
-        assert_eq!(merkle_tree.hash.0, hash_root);
+        assert_eq!(merkle_tree.root.hash.0, hash_root);
 
     }
 
@@ -200,13 +217,13 @@ mod tests {
         let hash_root = hasher_root.finish();
 
 
-        let left_child_hash = merkle_tree_42.leftChild.unwrap().hash.0;
+        let left_child_hash = merkle_tree_42.root.leftChild.unwrap().hash.0;
         assert_eq!(left_child_hash, hash1);
 
-        let right_child_hash = merkle_tree_42.rightChild.unwrap().hash.0;
+        let right_child_hash = merkle_tree_42.root.rightChild.unwrap().hash.0;
         assert_eq!(right_child_hash, hash2);
 
-        assert_eq!(merkle_tree_42.hash.0, hash_root);
+        assert_eq!(merkle_tree_42.root.hash.0, hash_root);
 
     }
 
@@ -245,16 +262,16 @@ mod tests {
         let hash_root = hasher_root.finish();
         
         
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().leftChild.unwrap().hash.0, hashed_ints[0]);
-        assert_eq!(merkle_tree.leftChild.clone().unwrap().rightChild.unwrap().hash.0, hashed_ints[1]);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().leftChild.unwrap().hash.0, hashed_ints[2]);
-        assert_eq!(merkle_tree.rightChild.clone().unwrap().rightChild.unwrap().hash.0, hashed_ints[3]);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().leftChild.unwrap().hash.0, hashed_ints[0]);
+        assert_eq!(merkle_tree.root.leftChild.clone().unwrap().rightChild.unwrap().hash.0, hashed_ints[1]);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().leftChild.unwrap().hash.0, hashed_ints[2]);
+        assert_eq!(merkle_tree.root.rightChild.clone().unwrap().rightChild.unwrap().hash.0, hashed_ints[3]);
         
-        assert_eq!(merkle_tree.leftChild.unwrap().hash.0, hash1);
-        assert_eq!(merkle_tree.rightChild.unwrap().hash.0, hash2);
+        assert_eq!(merkle_tree.root.leftChild.unwrap().hash.0, hash1);
+        assert_eq!(merkle_tree.root.rightChild.unwrap().hash.0, hash2);
 
 
-        assert_eq!(merkle_tree.hash.0, hash_root);
+        assert_eq!(merkle_tree.root.hash.0, hash_root);
 
     }
 }


### PR DESCRIPTION
- Small bugfix where when cloning an element if the amount of elements in a layer wasn't even its children weren't being separately cloned, resulting in the new clone pointing to the original's children (rather than new copies of them)
- Differentiated root node in a new struct, adding a size value to it too